### PR TITLE
Start control panels with a dynamic supervisor

### DIFF
--- a/lib/jeff.ex
+++ b/lib/jeff.ex
@@ -1,2 +1,25 @@
 defmodule Jeff do
+  alias Jeff.ControlPanel
+
+  import ControlPanel.Registry, only: [via: 1]
+
+  def start_control_panel(name, opts \\ []) do
+    :ok = ControlPanel.Supervisor.start_child(name, opts)
+  end
+
+  def stop_control_panel(name) do
+    :ok = ControlPanel.Supervisor.terminate_child(name)
+  end
+
+  def get_control_panels() do
+    ControlPanel.Supervisor.which_children()
+  end
+
+  def connect_device(name, address, opts) do
+    :ok = ControlPanel.add_device(via(name), address, opts)
+  end
+
+  def subscribe(name) do
+    :ok = ControlPanel.PubSub.subscribe(name)
+  end
 end

--- a/lib/jeff/application.ex
+++ b/lib/jeff/application.ex
@@ -1,0 +1,19 @@
+defmodule Jeff.Application do
+  @moduledoc false
+
+  use Application
+
+  alias Jeff.ControlPanel
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {Registry, keys: :unique, name: ControlPanel.Registry},
+      ControlPanel.PubSub,
+      ControlPanel.Supervisor
+    ]
+
+    opts = [strategy: :one_for_one, name: Jeff.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/jeff/bus.ex
+++ b/lib/jeff/bus.ex
@@ -6,8 +6,7 @@ defmodule Jeff.Bus do
             reply: nil,
             cursor: nil,
             poll: [],
-            conn: nil,
-            handler: nil
+            conn: nil
 
   def new(_opts \\ []) do
     %__MODULE__{}

--- a/lib/jeff/control_panel/pub_sub.ex
+++ b/lib/jeff/control_panel/pub_sub.ex
@@ -1,0 +1,30 @@
+defmodule Jeff.ControlPanel.PubSub do
+  @moduledoc false
+
+  @registry __MODULE__
+
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 500
+    }
+  end
+
+  def start_link() do
+    Registry.start_link(name: @registry, keys: :duplicate)
+  end
+
+  def subscribe(name) do
+    {:ok, _} = Registry.register(@registry, name, [])
+    :ok
+  end
+
+  def publish(name, message) do
+    Registry.dispatch(@registry, name, fn entries ->
+      for {pid, _} <- entries, do: send(pid, message)
+    end)
+  end
+end

--- a/lib/jeff/control_panel/registry.ex
+++ b/lib/jeff/control_panel/registry.ex
@@ -1,0 +1,19 @@
+defmodule Jeff.ControlPanel.Registry do
+  @moduledoc false
+
+  def via(name) do
+    {:via, Registry, {__MODULE__, name}}
+  end
+
+  def name(pid) do
+    Registry.keys(__MODULE__, pid)
+    |> List.first()
+  end
+
+  def pid(name) do
+    case Registry.lookup(__MODULE__, name) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+end

--- a/lib/jeff/control_panel/supervisor.ex
+++ b/lib/jeff/control_panel/supervisor.ex
@@ -1,0 +1,34 @@
+defmodule Jeff.ControlPanel.Supervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  alias Jeff.ControlPanel
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  def start_child(name, opts) do
+    spec = ControlPanel.child_spec(name, opts)
+    {:ok, _pid} = DynamicSupervisor.start_child(__MODULE__, spec)
+
+    :ok
+  end
+
+  def which_children() do
+    Supervisor.which_children(__MODULE__)
+    |> Enum.map(fn {_, pid, _, _} -> pid end)
+    |> Enum.map(&ControlPanel.Registry.name/1)
+  end
+
+  def terminate_child(name) do
+    pid = ControlPanel.Registry.pid(name)
+    :ok = DynamicSupervisor.terminate_child(__MODULE__, pid)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule Jeff.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :crypto]
+      extra_applications: [:logger, :crypto],
+      mod: {Jeff.Application, []}
     ]
   end
 


### PR DESCRIPTION
This change creates a top-level API that supports the following:

- Starting / stopping ControlPanel processes with a dynamic supervisor
- Connecting peripheral devices
- Subscribing to receive ControlPanel event messages

Example:

```elixir
iex> Jeff.get_control_panels()
[]
iex> Jeff.start_control_panel("default", serial_port: "/dev/ttyUSB0")
:ok
iex> Jeff.get_control_panels()
["default"]
iex> Jeff.connect_device("default", 0x01, check_scheme: :crc)
:ok
iex> Jeff.subscribe("default")
:ok
iex> flush
{:keypress, "default", 1,
 %Jeff.Reply.KeypadData{count: 1, keys: "7", reader: 0}}
{:raw, "default", 1,
 %Jeff.Reply.CardData{
   data: <<50, 92, 86, 192>>,
   format: 0,
   length: 26,
   reader: 0
 }}
:ok
iex> Jeff.stop_control_panel("default")
:ok
iex> Jeff.get_control_panels()
[]
```