### PR TITLE
Calculate device reply timeout / offline status

### DIFF
--- a/lib/jeff/device.ex
+++ b/lib/jeff/device.ex
@@ -1,12 +1,31 @@
 defmodule Jeff.Device do
+  @moduledoc false
+
+  @type device_address :: 0..127
+  @type check_scheme :: :checksum | :crc
+  @type sequence_number :: 0..3
+
+  @type t :: %__MODULE__{
+          address: device_address(),
+          check_scheme: check_scheme(),
+          security?: boolean(),
+          secure_channel: term(),
+          sequence: sequence_number(),
+          commands: :queue.queue(term()),
+          last_valid_reply: non_neg_integer()
+        }
+
   defstruct address: 0x7F,
             check_scheme: :checksum,
             security?: false,
             secure_channel: nil,
             sequence: 0,
-            commands: :queue.new()
+            commands: :queue.new(),
+            last_valid_reply: nil
 
   alias Jeff.{Command, SecureChannel}
+
+  @offline_threshold_ms 8000
 
   def new(params \\ []) do
     secure_channel = SecureChannel.new()
@@ -20,7 +39,24 @@ defmodule Jeff.Device do
     %{device | sequence: next_sequence(n)}
   end
 
+  @spec receive_valid_reply(t()) :: t()
+  def receive_valid_reply(device) do
+    device |> maybe_set_last_valid_reply() |> inc_sequence()
+  end
+
+  defp maybe_set_last_valid_reply(%{sequence: 0} = device), do: device
+
+  defp maybe_set_last_valid_reply(device) do
+    %{device | last_valid_reply: System.monotonic_time(:millisecond)}
+  end
+
   defp next_sequence(n), do: rem(n, 3) + 1
+
+  def online?(%{last_valid_reply: nil}), do: false
+
+  def online?(%{last_valid_reply: last_valid_reply}) do
+    last_valid_reply - System.monotonic_time(:millisecond) < @offline_threshold_ms
+  end
 
   def send_command(%{commands: commands} = device, command) do
     commands = :queue.in(command, commands)

--- a/lib/jeff/events/card_read.ex
+++ b/lib/jeff/events/card_read.ex
@@ -4,12 +4,12 @@ defmodule Jeff.Events.CardRead do
   """
 
   @type t :: %__MODULE__{
-    address: 0..127,
-    data: binary(),
-    format: non_neg_integer(),
-    length: non_neg_integer(),
-    reader: non_neg_integer()
-  }
+          address: 0..127,
+          data: binary(),
+          format: non_neg_integer(),
+          length: non_neg_integer(),
+          reader: non_neg_integer()
+        }
   defstruct ~w[address data format length reader]a
 
   alias Jeff.Reply

--- a/lib/jeff/events/keypress.ex
+++ b/lib/jeff/events/keypress.ex
@@ -4,11 +4,11 @@ defmodule Jeff.Events.Keypress do
   """
 
   @type t :: %__MODULE__{
-    address: 0..127,
-    count: non_neg_integer(),
-    keys: binary(),
-    reader: non_neg_integer()
-  }
+          address: 0..127,
+          count: non_neg_integer(),
+          keys: binary(),
+          reader: non_neg_integer()
+        }
 
   defstruct ~w[address count keys reader]a
 

--- a/lib/jeff/transport.ex
+++ b/lib/jeff/transport.ex
@@ -1,160 +1,114 @@
 defmodule Jeff.Transport do
-  require Logger
+  @moduledoc false
+
   use Connection
   alias Circuits.UART
+  require Logger
 
-  alias Jeff.Message
+  @type baud() :: 9600 | 19200 | 38400 | 57600 | 115_200 | 230_400
 
-  @defaults [
-    speed: 9600,
-    active: true,
-    timeout: 5000,
-    framing: Jeff.Framing,
-    rx_framing_timeout: 200
-  ]
+  @type args() :: [
+          port: binary(),
+          speed: baud()
+        ]
 
-  def start_link({device, owner, opts}) do
-    Connection.start_link(__MODULE__, {device, owner, opts})
+  @type t() :: [
+          port: binary(),
+          speed: baud(),
+          uart: pid()
+        ]
+
+  defstruct port: nil, speed: nil, uart: nil
+
+  @spec start_link(args()) :: GenServer.on_start()
+  def start_link(init_args) do
+    Connection.start_link(__MODULE__, init_args)
   end
 
-  def send_message(conn, message) do
-    case Connection.call(conn, {:send_message, message}) do
-      :ok -> :ok
-      {:ok, msg} -> {:ok, msg}
-      {:error, error} -> {:error, error}
-    end
+  @spec send(GenServer.server(), binary()) :: :ok | {:error, term()}
+  def send(conn, data), do: Connection.call(conn, {:send, data})
+
+  @spec recv(GenServer.server(), non_neg_integer()) :: {:ok, binary()} | {:error, term()}
+  def recv(conn, timeout) do
+    Connection.call(conn, {:recv, timeout})
   end
 
-  def set_speed(conn, speed) do
-    Connection.call(conn, {:set_speed, speed})
-  end
+  @spec close(GenServer.server()) :: {:close, GenServer.from()}
+  def close(conn), do: Connection.call(conn, :close)
 
-  def open(conn) do
-    Connection.call(conn, :open)
-  end
-
-  def close(conn) do
-    Connection.call(conn, :close)
-  end
-
-  def reopen(conn) do
-    _ = close(conn)
-    Process.sleep(200)
-    open(conn)
-  end
-
-  # Connection API
-
-  def init({device, owner, opts}) do
-    opts = Keyword.merge(@defaults, opts)
+  @impl Connection
+  def init(init_args) do
+    port = Keyword.fetch!(init_args, :port)
+    speed = Keyword.fetch!(init_args, :speed)
     {:ok, uart} = UART.start_link()
 
-    s = %{
-      device: device,
-      opts: opts,
-      uart: uart,
-      owner: owner,
-      connection: :disconnected,
-      callback: nil
-    }
+    s = %{port: port, speed: speed, uart: uart}
 
     {:connect, :init, s}
   end
 
-  def connect(info, %{uart: uart, device: device, opts: opts} = s) do
-    Logger.info("Connecting to channel at #{device}")
+  @impl Connection
+  def connect(_, %{port: port, speed: speed, uart: uart} = s) do
+    opts = [speed: speed, active: false, framing: Jeff.Framing]
 
-    case info do
-      {_, from} -> Connection.reply(from, :ok)
-      _ -> :noop
-    end
-
-    case UART.open(uart, device, opts) do
+    case UART.open(uart, port, opts) do
       :ok ->
-        send(s.owner, :connected)
-        {:ok, %{s | connection: :connected}}
+        {:ok, s}
 
       {:error, _} ->
         {:backoff, 1000, s}
     end
   end
 
-  def disconnect(info, %{uart: pid, device: device} = s) do
-    Logger.info("Disconnecting from channel at #{device}")
-    _ = UART.drain(pid)
-    :ok = UART.close(pid)
-
-    s = %{s | connection: :disconnected}
-
-    send(s.owner, :disconnected)
+  @impl Connection
+  def disconnect(info, %{uart: uart} = s) do
+    _ = UART.drain(uart)
+    :ok = UART.close(uart)
 
     case info do
       {:close, from} ->
         Connection.reply(from, :ok)
-        {:noconnect, s}
 
       {:error, :closed} ->
-        Logger.error("Channel connection closed")
-        {:connect, :reconnect, s}
+        Logger.error("Serial connection closed")
 
       {:error, reason} ->
-        Logger.error("Channel connection error: #{inspect(reason)}")
-        {:connect, :reconnect, s}
+        Logger.error("Serial connection error: #{inspect(reason)}")
     end
+
+    {:connect, :reconnect, %{s | uart: nil}}
   end
 
+  @impl Connection
   def handle_call(_, _, %{uart: nil} = s) do
     {:reply, {:error, :closed}, s}
   end
 
-  def handle_call({:set_speed, speed}, _, %{uart: pid, opts: opts} = s) do
-    :ok = UART.configure(pid, speed: speed)
-    new_state = %{s | opts: Keyword.put(opts, :speed, speed)}
-    {:reply, :ok, new_state}
-  end
-
-  def handle_call({:send_message, message}, from, %{uart: pid} = s) do
-    case UART.write(pid, <<0xFF>> <> message.bytes) do
+  @impl Connection
+  def handle_call({:send, data}, _, %{uart: uart} = s) do
+    case UART.write(uart, <<0xFF>> <> data) do
       :ok ->
-        {:noreply, %{s | callback: from}}
+        {:reply, :ok, s}
 
       {:error, _} = error ->
         {:disconnect, error, error, s}
     end
   end
 
-  def handle_call(:open, from, s) do
-    {:connect, {:open, from}, s}
+  def handle_call({:recv, timeout}, _, %{uart: uart} = s) do
+    case UART.read(uart, timeout) do
+      {:ok, <<>>} ->
+        {:reply, {:error, :timeout}, s}
+
+      {:ok, _} = ok ->
+        {:reply, ok, s}
+
+      {:error, _} = error ->
+        {:disconnect, error, error, s}
+    end
   end
 
   def handle_call(:close, from, s) do
     {:disconnect, {:close, from}, s}
-  end
-
-  def handle_info({:circuits_uart, _, data}, %{connection: :connected} = s) do
-    case recv(data) do
-      {:reply, message} ->
-        GenServer.reply(s.callback, {:ok, message})
-        {:noreply, s}
-
-      {:disconnect, error} ->
-        {:disconnect, error, s}
-    end
-  end
-
-  def handle_info(_, s) do
-    {:noreply, s}
-  end
-
-  defp recv(bytes) when is_binary(bytes) do
-    {:reply, Message.decode(bytes)}
-  end
-
-  defp recv({:error, :timeout} = timeout) do
-    {:reply, timeout}
-  end
-
-  defp recv({:error, _} = error) do
-    {:disconnect, error}
   end
 end


### PR DESCRIPTION
OSDP spec defines:
- A maximum time of 200ms to wait for a reply before timing out and going on do the next device
- A maximum time of 8 seconds to wait for a valid reply before marking the device offline

Times out replies after 200ms and allows calculation of device online status through `last_valid_reply` timestamp property.