### PR TITLE
Check OSDP address availability

### DIFF
--- a/lib/jeff/bus.ex
+++ b/lib/jeff/bus.ex
@@ -22,6 +22,10 @@ defmodule Jeff.Bus do
     Map.fetch!(registry, address)
   end
 
+  def registered?(%{registry: registry}, address) do
+    is_map_key(registry, address)
+  end
+
   def put_device(%{cursor: cursor} = bus, device) do
     register(bus, cursor, device)
   end

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -11,6 +11,15 @@ defmodule BusTest do
     assert Bus.get_device(bus, address).address == address
   end
 
+  test "registered?" do
+    address = 0x23
+    bus = Bus.new()
+
+    refute Bus.registered?(bus, address)
+    bus = Bus.add_device(bus, address: address)
+    assert Bus.registered?(bus, address)
+  end
+
   test "sending a command" do
     address = 0x23
     command = Command.new(address, POLL)


### PR DESCRIPTION
Checks whether an address is available to register to a bus.

This is will be needed to be able to automatically address readers.