### PR TITLE
Handle ACU termination gracefully

### DIFF
--- a/lib/jeff/acu.ex
+++ b/lib/jeff/acu.ex
@@ -172,6 +172,11 @@ defmodule Jeff.ACU do
     {:noreply, state}
   end
 
+  @impl GenServer
+  def terminate(_reason, state) do
+    Transport.close(state.conn)
+  end
+
   # Helper functions
 
   defp handle_reply(state, %{name: CCRYPT} = reply) do

--- a/lib/jeff/transport.ex
+++ b/lib/jeff/transport.ex
@@ -69,18 +69,21 @@ defmodule Jeff.Transport do
     _ = UART.drain(uart)
     :ok = UART.close(uart)
 
+    s = %{s | uart: nil}
+
     case info do
       {:close, from} ->
         Connection.reply(from, :ok)
+        {:stop, :normal, s}
 
       {:error, :closed} ->
         Logger.error("Serial connection closed")
+        {:connect, :reconnect, %{s | uart: nil}}
 
       {:error, reason} ->
         Logger.error("Serial connection error: #{inspect(reason)}")
+        {:connect, :reconnect, %{s | uart: nil}}
     end
-
-    {:connect, :reconnect, %{s | uart: nil}}
   end
 
   @impl Connection


### PR DESCRIPTION
If you were to stop the ACU process outside of supervision (i.e. `GenServer.stop(acu)`)
it will leave the Transport connection and Circuits.UART reference open and orphaned.
This causes issues later on when attempting to start the ACU again.

This change adds handling so that gracefully terminating the ACU process will propgate
to the Transport and Circuits.UART processes as well