### PR TITLE
Reset communication on sequence number desync

### DIFF
--- a/lib/jeff/acu.ex
+++ b/lib/jeff/acu.ex
@@ -195,6 +195,13 @@ defmodule Jeff.ACU do
     Bus.put_device(state, device)
   end
 
+  # NAK - unexpected sequence number
+  defp handle_reply(state, %{name: NAK, data: %Reply.ErrorCode{code: 0x04}}) do
+    device = Bus.current_device(state)
+    device = Device.reset(device)
+    Bus.put_device(state, device)
+  end
+
   defp handle_reply(state, _reply), do: state
 
   defp handle_recv(

--- a/lib/jeff/device.ex
+++ b/lib/jeff/device.ex
@@ -42,6 +42,16 @@ defmodule Jeff.Device do
     %{device | sequence: next_sequence(n)}
   end
 
+  @doc """
+  Resets communication with a PD by setting the sequence number to 0 and resetting
+  the secure channel state. Useful when a communication with a PD gets out of sync,
+  such as when the PD reboots.
+  """
+  @spec reset(t()) :: t()
+  def reset(device) do
+    %{device | sequence: 0, last_valid_reply: 0, secure_channel: SecureChannel.new()}
+  end
+
   @spec receive_valid_reply(t()) :: t()
   def receive_valid_reply(device) do
     device |> maybe_set_last_valid_reply() |> inc_sequence()

--- a/test/device_test.exs
+++ b/test/device_test.exs
@@ -30,6 +30,22 @@ defmodule DeviceTest do
     assert device.sequence == 1
   end
 
+  test "reset device communication" do
+    device = Device.new()
+    assert device.sequence == 0
+    assert device = Device.inc_sequence(device)
+    assert device.sequence == 1
+    assert device = Device.inc_sequence(device)
+    assert device.sequence == 2
+
+    secure_channel = device.secure_channel
+
+    assert device = Device.reset(device)
+    assert device.sequence == 0
+    assert device.last_valid_reply == 0
+    assert device.secure_channel != secure_channel
+  end
+
   test "send commands" do
     command = Command.new(0x01, POLL)
     device = Device.new()


### PR DESCRIPTION
If the PD reports that it received an unexpected sequence number, reset communication with that device. This happens frequently when a PD reboots.