### PR TITLE
Fix requests to offline devices 

### DIFF
--- a/lib/jeff.ex
+++ b/lib/jeff.ex
@@ -3,12 +3,19 @@ defmodule Jeff do
   Control an Access Control Unit (ACU) and send commands to a Peripheral Device (PD)
   """
 
-  alias Jeff.{ACU, Command, Device, MFG.Encoder, Reply}
+  alias Jeff.ACU
+  alias Jeff.Command
+  alias Jeff.Device
+  alias Jeff.MFG.Encoder
+  alias Jeff.Reply
+  alias Jeff.Reply.ErrorCode
 
   @type acu() :: GenServer.server()
   @type device_opt() :: ACU.device_opt()
   @type osdp_address() :: 0x00..0x7F
   @type vendor_code() :: 0x000000..0xFFFFFF
+
+  @type cmd_err :: {:error, :timeout | ErrorCode.t()}
 
   @doc """
   Start an ACU process.
@@ -37,35 +44,35 @@ defmodule Jeff do
   @doc """
   Requests the return of the PD ID Report.
   """
-  @spec id_report(acu(), osdp_address()) :: Reply.IdReport.t() | Reply.ErrorCode.t()
+  @spec id_report(acu(), osdp_address()) :: Reply.IdReport.t() | cmd_err()
   def id_report(acu, address) do
-    ACU.send_command(acu, address, ID).data
+    ACU.send_command(acu, address, ID) |> handle_reply()
   end
 
   @doc """
   Requests the PD to return a list of its functional capabilities, such as the
   type and number of input points, outputs points, reader ports, etc.
   """
-  @spec capabilities(acu(), osdp_address()) :: Reply.Capabilities.t() | Reply.ErrorCode.t()
+  @spec capabilities(acu(), osdp_address()) :: Reply.Capabilities.t() | cmd_err()
   def capabilities(acu, address) do
-    ACU.send_command(acu, address, CAP).data
+    ACU.send_command(acu, address, CAP) |> handle_reply()
   end
 
   @doc """
   Instructs the PD to reply with a local status report.
   """
-  @spec local_status(acu(), osdp_address()) :: Reply.LocalStatus.t() | Reply.ErrorCode.t()
+  @spec local_status(acu(), osdp_address()) :: Reply.LocalStatus.t() | cmd_err()
   def local_status(acu, address) do
-    ACU.send_command(acu, address, LSTAT).data
+    ACU.send_command(acu, address, LSTAT) |> handle_reply()
   end
 
   @doc """
   Controls the LEDs associated with one or more readers.
   """
   @spec set_led(acu(), osdp_address(), [Command.LedSettings.param()]) ::
-          Reply.ACK | Reply.ErrorCode.t()
+          Reply.ACK | cmd_err()
   def set_led(acu, address, params) do
-    ACU.send_command(acu, address, LED, params).data
+    ACU.send_command(acu, address, LED, params) |> handle_reply()
   end
 
   @doc """
@@ -73,40 +80,41 @@ defmodule Jeff do
   that may be associated with a reader.
   """
   @spec set_buzzer(acu(), osdp_address(), [Command.BuzzerSettings.param()]) ::
-          Reply.ACK | Reply.ErrorCode.t()
+          Reply.ACK | cmd_err()
   def set_buzzer(acu, address, params) do
-    ACU.send_command(acu, address, BUZ, params).data
+    ACU.send_command(acu, address, BUZ, params) |> handle_reply()
   end
 
   @doc """
   Sets the PD's communication parameters.
   """
   @spec set_com(acu(), osdp_address(), [Command.ComSettings.param()]) ::
-          Reply.ComData.t() | Reply.ErrorCode.t()
+          Reply.ComData.t() | cmd_err()
   def set_com(acu, address, params) do
-    ACU.send_command(acu, address, COMSET, params).data
+    ACU.send_command(acu, address, COMSET, params) |> handle_reply()
   end
 
   @doc """
   Instructs the PD to reply with an input status report.
   """
-  @spec input_status(acu(), osdp_address()) :: Reply.InputStatus.t() | Reply.ErrorCode.t()
+  @spec input_status(acu(), osdp_address()) :: Reply.InputStatus.t() | cmd_err()
   def input_status(acu, address) do
-    ACU.send_command(acu, address, ISTAT).data
+    ACU.send_command(acu, address, ISTAT) |> handle_reply()
   end
 
   @doc """
   Instructs the PD to reply with an output status report.
   """
-  @spec output_status(acu(), osdp_address()) :: Reply.InputStatus.t() | Reply.ErrorCode.t()
+  @spec output_status(acu(), osdp_address()) :: Reply.OutputStatus.t() | cmd_err()
   def output_status(acu, address) do
-    ACU.send_command(acu, address, OSTAT).data
+    ACU.send_command(acu, address, OSTAT) |> handle_reply()
   end
 
   @doc """
   Sends a manufacturer-specific command to the PD.
   """
-  @spec mfg(acu(), osdp_address(), Encoder.t() | [Command.Mfg.param()]) :: Jeff.Reply.t()
+  @spec mfg(acu(), osdp_address(), Encoder.t() | [Command.Mfg.param()]) ::
+          Reply.MfgReply.t() | cmd_err()
   def mfg(acu, address, mfg_command) when is_struct(mfg_command) do
     vendor_code = Encoder.vendor_code(mfg_command)
     data = Encoder.encode(mfg_command)
@@ -115,6 +123,12 @@ defmodule Jeff do
   end
 
   def mfg(acu, address, params) when is_list(params) do
-    ACU.send_command(acu, address, MFG, params)
+    ACU.send_command(acu, address, MFG, params) |> handle_reply()
   end
+
+  defp handle_reply({:ok, %{data: %ErrorCode{code: code} = data}}) when code > 0,
+    do: {:error, data}
+
+  defp handle_reply({:ok, %{data: data}}), do: data
+  defp handle_reply(err), do: err
 end

--- a/lib/jeff/acu.ex
+++ b/lib/jeff/acu.ex
@@ -264,6 +264,11 @@ defmodule Jeff.ACU do
   end
 
   defp handle_recv({:error, :timeout}, state) do
+    # Make sure to report the timeout to any potential callers
+    _ =
+      if from = get_in(state.command, [Access.key(:caller)]),
+        do: GenServer.reply(from, {:error, :timeout})
+
     %{state | reply: :timeout}
   end
 

--- a/lib/jeff/device.ex
+++ b/lib/jeff/device.ex
@@ -79,11 +79,6 @@ defmodule Jeff.Device do
   end
 
   @spec next_command(t()) :: {t(), Command.t()}
-  def next_command(%{sequence: 0, address: address} = device) do
-    command = Command.new(address, POLL)
-    {device, command}
-  end
-
   def next_command(
         %{security?: true, secure_channel: %{initialized?: false}, address: address} = device
       ) do

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -176,13 +176,13 @@ defmodule BusTest do
     bus = Bus.tick(bus)
     assert bus.poll == []
     assert bus.cursor == 0x1
-    assert bus.command == poll_command
+    assert bus.command == id_command
     assert bus.reply == nil
 
     bus = Bus.receive_reply(bus, ack_reply)
     assert bus.poll == []
     assert bus.cursor == 0x1
-    assert bus.command == poll_command
+    assert bus.command == id_command
     assert bus.reply == ack_reply
 
     bus = Bus.tick(bus)
@@ -206,13 +206,13 @@ defmodule BusTest do
     bus = Bus.tick(bus)
     assert bus.poll == []
     assert bus.cursor == 0x1
-    assert bus.command == id_command
+    assert bus.command == poll_command
     assert bus.reply == nil
 
     bus = Bus.receive_reply(bus, pdid_reply)
     assert bus.poll == []
     assert bus.cursor == 0x1
-    assert bus.command == id_command
+    assert bus.command == poll_command
     assert bus.reply == pdid_reply
 
     bus = Bus.tick(bus)

--- a/test/device_test.exs
+++ b/test/device_test.exs
@@ -54,16 +54,13 @@ defmodule DeviceTest do
     assert device.commands == {[command], []}
   end
 
-  test "next command is POLL if sequence is 0" do
+  test "next command is used if sequence is 0" do
     queued_command = Command.new(0x01, ID)
-    poll_command = Command.new(0x01, POLL)
     device = Device.new(address: 0x01)
     device = Device.send_command(device, queued_command)
     assert device.sequence == 0
 
-    {_device, next_command} = Device.next_command(device)
-
-    assert next_command == poll_command
+    assert {_device, ^queued_command} = Device.next_command(device)
   end
 
   test "next command is CHLNG if security not initialized" do


### PR DESCRIPTION
This is for situations where the device is registered, but is offline (possibly not powered up or addressed correctly yet)

In those cases, a command sent for the device would never get processed and this would subsequently fail with a GenServer timeout. This is slightly misleading and could cause other process failures.

The changes here fix that by removing the epectation that the first command to a device would always be a `POLL`. Instead, whatever command is next in the queue would be sent with sequence 0 and would either establish communication or fail with a timeout that is handled in the ACU process.

After reading the spec a little closer and testing, there does not seem to be a requirement to sequence 0 always being POLL, so this should be a safe change.