### PR TITLE
Add OSDP packet tracing

### DIFF
--- a/lib/jeff/acu.ex
+++ b/lib/jeff/acu.ex
@@ -74,6 +74,12 @@ defmodule Jeff.ACU do
     GenServer.call(acu, {:check_address, address})
   end
 
+  @doc """
+  Get the state of the ACU
+  """
+  @spec state(acu()) :: Bus.t()
+  def state(acu), do: GenServer.call(acu, :state)
+
   @impl GenServer
   def init(opts) do
     controlling_process = Keyword.get(opts, :controlling_process)
@@ -135,7 +141,6 @@ defmodule Jeff.ACU do
     {:reply, status, state}
   end
 
-  @impl GenServer
   def handle_call({:add_device, address, opts}, _from, state) do
     opts = Keyword.merge(opts, address: address)
     state = Bus.add_device(state, opts)
@@ -148,6 +153,8 @@ defmodule Jeff.ACU do
     state = Bus.remove_device(state, address)
     {:reply, device, state}
   end
+
+  def handle_call(:state, _from, state), do: {:reply, state, state}
 
   @impl GenServer
   def handle_info(:tick, %{command: nil, reply: nil} = state) do

--- a/lib/jeff/tracer.ex
+++ b/lib/jeff/tracer.ex
@@ -1,0 +1,109 @@
+defmodule Jeff.Tracer do
+  @moduledoc false
+  use GenServer
+
+  require Logger
+
+  @som Jeff.Message.start_of_message()
+  @poll 0x60
+  @ack 0x40
+
+  @defaults [
+    ignore_polls: true,
+    ignore_partials: false,
+    ignore_marks: true,
+    # 100 bytes
+    partials_limit: 100,
+    partials: []
+  ]
+
+  @type option ::
+          {:enabled, boolean}
+          | {:ignore_polls, boolean()}
+          | {:ignore_partials, boolean()}
+          | {:ignore_marks, boolean()}
+          | {:partials_limit, pos_integer()}
+
+  @spec start_link([option()]) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Send bytes to the tracer logger
+  """
+  @spec log(GenServer.server(), :rx | :tx | :partial, iodata()) :: :ok
+  def log(tracer, type, bytes), do: GenServer.cast(tracer, {:log, type, bytes})
+
+  @impl GenServer
+  def init(opts) do
+    state =
+      @defaults
+      |> Keyword.merge(Application.get_env(:jeff, :tracer, []))
+      |> Keyword.merge(opts)
+      |> Map.new()
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:configure, opts}, _from, state) do
+    {:reply, :ok, Map.merge(state, Map.new(opts))}
+  end
+
+  @impl GenServer
+  def handle_cast({:log, :partial, _bytes}, %{ignore_partials: true} = state) do
+    {:noreply, state}
+  end
+
+  def handle_cast({:log, :partial, bytes}, %{ignore_partials: false, partials: partials} = state) do
+    state =
+      cond do
+        state.ignore_marks and all_marks?(bytes) ->
+          state
+
+        length(partials) >= state.partials_limit ->
+          maybe_log_partials([bytes | partials])
+          %{state | partials: []}
+
+        true ->
+          %{state | partials: [bytes | partials]}
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:log, type, bytes}, state) do
+    maybe_log_partials(state.partials)
+    maybe_log(type, bytes, state)
+    {:noreply, %{state | partials: []}}
+  end
+
+  defp all_marks?(<<>>), do: true
+  defp all_marks?([]), do: true
+  defp all_marks?([0xFF | rem]), do: all_marks?(rem)
+  defp all_marks?([next | rem]), do: all_marks?(next) and all_marks?(rem)
+  defp all_marks?(<<0xFF, rem::binary>>), do: all_marks?(rem)
+  defp all_marks?(<<_byte, _::binary>>), do: false
+
+  defp maybe_log_partials([]), do: :ok
+
+  defp maybe_log_partials(partials) do
+    bin = :binary.list_to_bin(Enum.reverse(partials))
+    Logger.debug(["[Jeff <-- RX]", IO.ANSI.yellow(), " partial: ", IO.ANSI.cyan(), inspect(bin)])
+  end
+
+  defp maybe_log(_, <<255, @som, _::4-bytes, @poll, _::binary>>, %{ignore_polls: true}), do: :ok
+  defp maybe_log(_, <<@som, _::4-bytes, @poll, _::binary>>, %{ignore_polls: true}), do: :ok
+  defp maybe_log(_, <<@som, 1::1, _::31, @ack, _::binary>>, %{ignore_polls: true}), do: :ok
+
+  defp maybe_log(type, bytes, _state) do
+    dir_type_str =
+      case type do
+        :tx -> [IO.ANSI.green(), "--> TX", IO.ANSI.cyan()]
+        :rx -> [IO.ANSI.white(), "<-- RX", IO.ANSI.cyan()]
+      end
+
+    Logger.debug(["[Jeff ", dir_type_str, "] ", inspect(bytes)])
+  end
+end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -1,0 +1,134 @@
+defmodule Jeff.TracerTest do
+  use ExUnit.Case, async: true
+
+  alias Jeff.Tracer
+
+  setup_all do
+    # Default state
+    {:ok, state} = Tracer.init([])
+    %{state: state}
+  end
+
+  test "default state", %{state: state} do
+    assert %{
+             ignore_polls: true,
+             ignore_partials: false,
+             ignore_marks: true,
+             partials_limit: 100,
+             partials: []
+           } = state
+  end
+
+  test "configuration change", %{state: state} do
+    new = [
+      ignore_polls: !state.ignore_polls,
+      ignore_partials: !state.ignore_partials,
+      ignore_marks: !state.ignore_marks,
+      partials_limit: state.partials_limit + 100
+    ]
+
+    {:reply, :ok, updated} = Tracer.handle_call({:configure, new}, self(), state)
+    assert updated.ignore_polls == !state.ignore_polls
+    assert updated.ignore_partials == !state.ignore_partials
+    assert updated.ignore_marks == !state.ignore_marks
+    assert updated.partials_limit == state.partials_limit + 100
+  end
+
+  test "can ignore partials when set", %{state: state} do
+    state = %{state | ignore_partials: true}
+
+    assert {:noreply, ^state} = Tracer.handle_cast({:log, :partial, <<123>>}, state)
+  end
+
+  test "can ignore marks when set", %{state: state} do
+    state = %{state | ignore_marks: true, ignore_partials: false}
+
+    assert {:noreply, ^state} = Tracer.handle_cast({:log, :partial, <<0xFF>>}, state)
+    assert {:noreply, ^state} = Tracer.handle_cast({:log, :partial, <<0xFF, 0xFF, 0xFF>>}, state)
+    assert {:noreply, ^state} = Tracer.handle_cast({:log, :partial, [<<0xFF>>]}, state)
+
+    assert {:noreply, ^state} =
+             Tracer.handle_cast({:log, :partial, [<<0xFF>>, 0xFF, [0xFF]]}, state)
+  end
+
+  test "can accumulate marks", %{state: state} do
+    state = %{state | ignore_marks: false, ignore_partials: false, partials: [<<123>>]}
+
+    assert {:noreply, %{partials: [<<0xFF>>, <<123>>]}} =
+             Tracer.handle_cast({:log, :partial, <<0xFF>>}, state)
+  end
+
+  test "logs partials and resets buffer when limit is reached", %{state: state} do
+    state = %{
+      state
+      | ignore_marks: true,
+        ignore_partials: false,
+        partials_limit: 1,
+        partials: [<<123>>]
+    }
+
+    {result, log} =
+      ExUnit.CaptureLog.with_log(fn -> Tracer.handle_cast({:log, :partial, <<253>>}, state) end)
+
+    assert {:noreply, %{partials: []}} = result
+    assert log =~ "[Jeff <-- RX]\e[33m partial: \e[36m<<123, 253>>"
+  end
+
+  test "accumulates partials", %{state: state} do
+    state = %{state | ignore_marks: true, ignore_partials: false, partials: [<<123>>]}
+
+    assert {:noreply, %{partials: [<<253>>, <<123>>]}} =
+             Tracer.handle_cast({:log, :partial, <<253>>}, state)
+  end
+
+  test "can ignore polls and acks", %{state: state} do
+    ack = <<83, 129, 8, 0, 6, 64, 106, 96>>
+    poll1 = <<255, 83, 1, 8, 0, 7, 96, 233, 85>>
+    poll2 = <<83, 1, 8, 0, 7, 96, 233, 85>>
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        Tracer.handle_cast({:log, :rx, ack}, state)
+        Tracer.handle_cast({:log, :tx, poll1}, state)
+        Tracer.handle_cast({:log, :tx, poll2}, state)
+      end)
+
+    assert log == ""
+  end
+
+  test "can log polls and acks", %{state: state} do
+    state = %{state | ignore_polls: false}
+
+    ack = <<83, 129, 8, 0, 6, 64, 106, 96>>
+    poll1 = <<255, 83, 1, 8, 0, 7, 96, 233, 85>>
+    poll2 = <<83, 1, 8, 0, 7, 96, 233, 85>>
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        Tracer.handle_cast({:log, :rx, ack}, state)
+        Tracer.handle_cast({:log, :tx, poll1}, state)
+        Tracer.handle_cast({:log, :tx, poll2}, state)
+      end)
+
+    assert log =~ "[Jeff \e[37m<-- RX\e[36m] #{inspect(ack)}"
+    assert log =~ "[Jeff \e[32m--> TX\e[36m] #{inspect(poll1)}"
+    assert log =~ "[Jeff \e[32m--> TX\e[36m] #{inspect(poll2)}"
+  end
+
+  test "logs partials when valid packet is logged", %{state: state} do
+    state = %{
+      state
+      | ignore_marks: true,
+        ignore_partials: false,
+        partials_limit: 1,
+        partials: [<<252>>]
+    }
+
+    {result, log} =
+      ExUnit.CaptureLog.with_log(fn -> Tracer.handle_cast({:log, :tx, <<253>>}, state) end)
+
+    assert {:noreply, %{partials: []}} = result
+    assert log =~ "[Jeff <-- RX]\e[33m partial: \e[36m<<252>>"
+    assert log =~ "[Jeff \e[32m--> TX\e[36m] <<253>>"
+  end
+end


### PR DESCRIPTION
This would've been helpful during a recent troubleshooting venture to confirm OSDP data expected on the line. It attempts to only log valid OSDP packets, but has configuration options to get all possible data on the transport if needed (which would be _very_ noisy). See `Jeff.enable_trace/2` for more info

![image](https://user-images.githubusercontent.com/11321326/236572478-71f34cb9-0632-490d-857a-6bb02556ab20.png)
