### PR TITLE
ENG: Fix bad state loops in OSDP

### DIFF
--- a/lib/jeff/acu.ex
+++ b/lib/jeff/acu.ex
@@ -220,8 +220,38 @@ defmodule Jeff.ACU do
 
   defp handle_reply(state, _reply), do: state
 
-  defp handle_recv(
-         {:ok, bytes},
+  defp handle_recv({:ok, bytes}, state) do
+    do_handle_recv(bytes, state)
+  rescue
+    e ->
+      Logger.warning("Jeff dropping malformed OSDP frame: #{Exception.message(e)}")
+
+      if from = get_in(state.command, [Access.key(:caller)]),
+        do: GenServer.reply(from, {:error, :bad_frame})
+
+      %{state | reply: :bad_frame}
+  end
+
+  defp handle_recv({:error, :timeout}, state) do
+    # Make sure to report the timeout to any potential callers
+    _ =
+      if from = get_in(state.command, [Access.key(:caller)]),
+        do: GenServer.reply(from, {:error, :timeout})
+
+    %{state | reply: :timeout}
+  end
+
+  defp handle_recv({:error, reason}, state) do
+    Logger.warning("Jeff transport error: #{inspect(reason)}")
+
+    if from = get_in(state.command, [Access.key(:caller)]),
+      do: GenServer.reply(from, {:error, reason})
+
+    %{state | reply: :bad_frame}
+  end
+
+  defp do_handle_recv(
+         bytes,
          %{controlling_process: controlling_process, command: command} = state
        ) do
     reply_message = Message.decode(bytes)
@@ -275,15 +305,6 @@ defmodule Jeff.ACU do
     end
 
     %{state | reply: reply}
-  end
-
-  defp handle_recv({:error, :timeout}, state) do
-    # Make sure to report the timeout to any potential callers
-    _ =
-      if from = get_in(state.command, [Access.key(:caller)]),
-        do: GenServer.reply(from, {:error, :timeout})
-
-    %{state | reply: :timeout}
   end
 
   defp send_data_oob(state, address, bytes, timeout) do

--- a/lib/jeff/bus.ex
+++ b/lib/jeff/bus.ex
@@ -98,6 +98,7 @@ defmodule Jeff.Bus do
   end
 
   defp maybe_validate_reply(%{reply: :timeout} = bus), do: bus
+  defp maybe_validate_reply(%{reply: :bad_frame} = bus), do: bus
 
   defp maybe_validate_reply(bus) do
     device = current_device(bus) |> Device.receive_valid_reply()

--- a/lib/jeff/control_info.ex
+++ b/lib/jeff/control_info.ex
@@ -35,7 +35,7 @@ defmodule Jeff.ControlInfo do
 
   def decode(byte) when is_integer(byte) do
     <<
-      0::size(4),
+      _::size(4),
       security?::size(1),
       check_scheme::size(1),
       sequence::size(2)

--- a/lib/jeff/framing.ex
+++ b/lib/jeff/framing.ex
@@ -34,13 +34,13 @@ defmodule Jeff.Framing do
 
   @impl true
   def frame_timeout(state) do
-    {:ok, [], %State{trace?: state.trace?}}
+    {:ok, [], clean_state(state)}
   end
 
   @impl true
-  def flush(:transmit, state), do: %State{trace?: state.trace?}
-  def flush(:receive, state), do: %State{trace?: state.trace?}
-  def flush(:both, state), do: %State{trace?: state.trace?}
+  def flush(:transmit, state), do: clean_state(state)
+  def flush(:receive, state), do: clean_state(state)
+  def flush(:both, state), do: clean_state(state)
 
   # start a buffer after a driver byte
   defp process_data(<<driver::binary-1, rest::binary>>, %{buffer: nil} = state) do
@@ -71,14 +71,14 @@ defmodule Jeff.Framing do
   defp process_data(data, %{buffer: buffer, packet_length: packet_length} = state)
        when byte_size(buffer) >= packet_length do
     <<packet::binary-size(packet_length), rest::binary>> = buffer
-    state = %State{packets: state.packets ++ [packet], trace?: state.trace?}
+    state = %{clean_state(state) | packets: state.packets ++ [packet]}
     process_data(rest <> data, state)
   end
 
   # # return when no more data to process
   defp process_data(<<>>, %{buffer: buffer, packets: packets} = state) do
     case buffer do
-      nil -> {:ok, packets, %State{trace?: state.trace?}}
+      nil -> {:ok, packets, clean_state(state)}
       _partial -> {:in_frame, packets, %{state | packets: []}}
     end
   end
@@ -87,4 +87,6 @@ defmodule Jeff.Framing do
   defp process_data(data, %{buffer: buffer} = state) do
     process_data(<<>>, %{state | buffer: buffer <> data})
   end
+
+  defp clean_state(state), do: %State{trace?: state.trace?, tracer: state.tracer}
 end

--- a/lib/jeff/transport.ex
+++ b/lib/jeff/transport.ex
@@ -113,6 +113,9 @@ defmodule Jeff.Transport do
   def handle_call({:recv, timeout}, _, %{uart: uart} = s) do
     case UART.read(uart, timeout) do
       {:ok, <<>>} ->
+        # Flush the receive buffer so any partial frame bytes accumulated during
+        # this timeout don't corrupt the next poll cycle's framing state.
+        _ = UART.flush(uart, :receive)
         {:reply, {:error, :timeout}, s}
 
       {:ok, bytes} = ok ->

--- a/test/bus_test.exs
+++ b/test/bus_test.exs
@@ -53,6 +53,36 @@ defmodule BusTest do
     assert bus.reply == reply
   end
 
+  test "valid reply advances device sequence number" do
+    address = 0x01
+    bus = Bus.new() |> Bus.add_device(address: address)
+    assert Bus.get_device(bus, address).sequence == 0
+
+    bus = bus |> Bus.tick() |> Bus.tick() |> Bus.tick()
+    bus = Bus.receive_reply(bus, Reply.new(address, ACK))
+    bus = Bus.tick(bus)
+
+    assert Bus.get_device(bus, address).sequence == 1
+  end
+
+  test "bad_frame reply does not advance device sequence number" do
+    address = 0x01
+    bus = Bus.new() |> Bus.add_device(address: address)
+
+    # complete a normal cycle to get sequence to a known non-zero value
+    bus = bus |> Bus.tick() |> Bus.tick() |> Bus.tick()
+    bus = Bus.receive_reply(bus, Reply.new(address, ACK))
+    bus = Bus.tick(bus)
+    assert Bus.get_device(bus, address).sequence == 1
+
+    # simulate a bad_frame on the next cycle
+    bus = bus |> Bus.tick() |> Bus.tick() |> Bus.tick()
+    bus = %{bus | reply: :bad_frame}
+    bus = Bus.tick(bus)
+
+    assert Bus.get_device(bus, address).sequence == 1
+  end
+
   test "tick" do
     bus = Bus.new()
     bus = Bus.add_device(bus, address: 0x1)

--- a/test/control_info_test.exs
+++ b/test/control_info_test.exs
@@ -33,4 +33,15 @@ defmodule ControlInfoTest do
     assert decode(0b00000100) == {0, :crc, false}
     assert decode(0b00001000) == {0, :checksum, true}
   end
+
+  test "ignores reserved bits in control info byte" do
+    # 0x53 (the OSDP SOM byte) has non-zero reserved bits but valid lower bits;
+    # a misbehaving peripheral can send this as a control byte and must not crash.
+    # 0x53 = 0b01010011 → reserved=0101, security?=0, check=0 (checksum), seq=3
+    assert decode(0x53) == {3, :checksum, false}
+    # reserved bits all set, lower nibble all zero
+    assert decode(0b11110000) == {0, :checksum, false}
+    # reserved bits set, crc, no security, seq=1
+    assert decode(0b10100101) == {1, :crc, false}
+  end
 end

--- a/test/framing_test.exs
+++ b/test/framing_test.exs
@@ -49,4 +49,31 @@ defmodule FramingTest do
     assert Framing.remove_framing(data, new_state) ==
              {:in_frame, [packet], %Framing.State{buffer: partial_packet, packet_length: 8}}
   end
+
+  test "flush :receive discards partial buffer" do
+    # Transport calls UART.flush(uart, :receive) on poll timeout so that a partial
+    # frame accumulated from a garbled reply can't corrupt the next poll cycle.
+    partial_state = %Framing.State{buffer: <<0x53, 0x7F, 0x06, 0x00>>, packet_length: 6}
+    clean_state = Framing.flush(:receive, partial_state)
+    assert clean_state.buffer == nil
+    assert clean_state.packet_length == nil
+    assert clean_state.packets == []
+  end
+
+  test "flush :receive preserves tracer configuration" do
+    # If trace? is true but tracer is dropped, the next partial-byte log crashes.
+    tracer = self()
+
+    partial_state = %Framing.State{
+      buffer: <<0x53, 0x7F, 0x06, 0x00>>,
+      packet_length: 6,
+      trace?: true,
+      tracer: tracer
+    }
+
+    clean_state = Framing.flush(:receive, partial_state)
+    assert clean_state.buffer == nil
+    assert clean_state.trace? == true
+    assert clean_state.tracer == tracer
+  end
 end

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -87,4 +87,13 @@ defmodule MessageTest do
   test "decode message with mac" do
     _message = Message.decode(<<83, 129, 14, 0, 15, 2, 22, 64, 12, 73, 225, 102, 51, 242>>)
   end
+
+  test "decode tolerates non-zero reserved bits in control byte" do
+    # Reproduces the crash seen when a peripheral sends 0x53 (the OSDP SOM byte)
+    # as the control info byte. The upper 4 bits are reserved and must be ignored.
+    # Frame: SOM | addr | len(2) | ctrl | code | check
+    # 0x53 as ctrl: reserved=0101, security?=0, check_scheme=checksum, seq=3
+    bytes = <<0x53, 0x01, 0x08, 0x00, 0x53, 0x40, 0x00, 0x00>>
+    assert %Message{} = Message.decode(bytes)
+  end
 end


### PR DESCRIPTION
### Background

Investigated a field incident where a reader LED went green after an access event and stayed stuck for ~34 minutes before recovering. During that window the reader was unresponsive to keypad input, and on recovery a backlog of buffered keypresses was delivered all at once.

Root cause analysis identified two separate bugs in Jeff. Most likely trigger was EM interference from the strike causing garbled bits.

### Bug 1: crash on non-zero reserved bits in OSDP control byte

The OSDP spec defines the upper 4 bits of the control info byte as reserved (should be 0), but some peripheral firmware sends non-zero values there. One specific case: a peripheral was sending `0x53` — which happens to be the OSDP SOM byte — as its control byte.

`ControlInfo.decode/1` was matching `<<0::size(4), ...>>`, which raised a `MatchError` on any byte with non-zero reserved bits, crashing the ACU GenServer.

**Fix:** Changed the match to `_::size(4)` to ignore reserved bits per spec. Added a try/rescue in `ACU.handle_recv/2` (extracted into `do_handle_recv/2`) so that any future malformed frame logs a warning and returns `{:error, :bad_frame}` to the caller rather than crashing the process.

### Bug 2: partial frame persisted indefinitely across poll timeouts

When a poll times out, `Circuits.UART.read/2` returns `{:ok, <<>>}` and leaves the framing state unchanged. Because Jeff never sets `rx_framing_timeout` (defaulting to 0 = wait forever), the `frame_timeout` callback that would reset framing state is never invoked.

If a peripheral sends a garbled reply that produces a partial frame — for example, the SOM byte arriving without the rest of the message — that partial frame sits in the framing buffer indefinitely. Every subsequent poll times out (the framing module waits for bytes that complete the partial frame, not a new SOM), the sequence number never advances, and from the peripheral's perspective its replies are never acknowledged. It holds and retransmits unacknowledged replies, which explains the keypress backlog on recovery.

In the field incident, the ~34-minute window corresponded exactly to the time between the crash that created the bad state and the next crash that incidentally reset it.

**Fix:** Call `UART.flush(uart, :receive)` on every poll timeout. The framing module's `flush(:receive, state)` callback returns a clean `%State{}`, discarding any partial buffer. This ensures a corrupted framing state can never outlive a single poll cycle.

### Tests

  - `control_info_test.exs`: reserved bits in control byte are ignored (including the `0x53` case)
  - `message_test.exs`: end-to-end `Message.decode/1` tolerates non-zero reserved bits
  - `framing_test.exs`: `flush(:receive, ...)` discards partial buffer state